### PR TITLE
Quick updates

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -51,6 +51,7 @@ return PhpCsFixer\Config::create()
         ],
         'blank_line_before_return' => true,
         'combine_consecutive_unsets' => true,
+        'method_chaining_indentation' => true,
         'no_blank_lines_after_phpdoc' => true,
         'no_extra_consecutive_blank_lines' => [
             'curly_brace_block',


### PR DESCRIPTION
- Each element of an array must be indented exactly once
- Class, trait and interface elements must be separated with one blank line.
- Method chaining MUST be properly indented.