### PR TITLE
Updated rules

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -36,7 +36,7 @@ return PhpCsFixer\Config::create()
         'no_mixed_echo_print' => [
             'use' => 'echo',
         ],
-        'no_unused_imports' => false,
+        'no_unused_imports' => true,
         'binary_operator_spaces' => [
             'default' => 'single_space',
         ],


### PR DESCRIPTION
- Turns off the removal of the `@return` when its value is `void`. It creates some weird docblocks when that's not in there.
- Adds explicit method visibility sorting order.
- Removes any sort order within the sorting groups.