### PR TITLE
Fix class attributes syntax

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -32,7 +32,9 @@ return PhpCsFixer\Config::create()
         // TODO: This isn't working, causes fixer to error.
         // 'increment_style' => ['style' => 'post'],
         'short_scalar_cast' => true,
-        'class_attributes_separation' => ['const', 'property', 'method'],
+        'class_attributes_separation' => [
+            'elements' => ['const', 'method', 'property'],
+        ],
         'no_mixed_echo_print' => [
             'use' => 'echo',
         ],


### PR DESCRIPTION
VS Code was erroring with the latest changes with a non-descript "Configuration error". Turns out that `class_attributes_separation` expects an array with a key of `elements`. I'm not sure when this changed, but this fixes the issue for me.