### PR TITLE
Ignore php-cs-fixer's cache file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+
+\.php_cs\.cache


### PR DESCRIPTION
If this file is used directly to fix files, it creates a cache file. This PR just ignores it. The title of the PR was verbose enough, just thought I would add much less brevity...