### PR TITLE
StyleCI yml file

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -14,7 +14,6 @@ enabled:
     - phpdoc_order
     - phpdoc_separation
     - property_separation
-    - short_list_syntax
     - ternary_to_null_coalescing
 
 disabled:


### PR DESCRIPTION
This file is for use with StyleCI. It matches our coding standards set forth in `.php_cs`.

This PR should get merged when the [StyleCI proposal](https://github.com/kirschbaum-development/coding-standards/pull/5) is approved.