### PR TITLE
Removes any space before and adds one space after return type hint colon

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -118,5 +118,8 @@ return PhpCsFixer\Config::create()
             ],
             'sortAlgorithm' => 'none',
         ],
+		'return_type_declaration' => [
+			'space_before' => 'none'
+		],
     ])
     ->setLineEnding("\n");

--- a/.php_cs
+++ b/.php_cs
@@ -118,8 +118,8 @@ return PhpCsFixer\Config::create()
             ],
             'sortAlgorithm' => 'none',
         ],
-		'return_type_declaration' => [
-			'space_before' => 'none'
-		],
+        'return_type_declaration' => [
+            'space_before' => 'none',
+        ],
     ])
     ->setLineEnding("\n");


### PR DESCRIPTION
If a type declaration is specified this will fix it to have exactly one space after the colon and no space before it. The output will look like:

```bash
public function functionName(): type
{
    ....
}
```

Right now our ruleset is not fixing spacing on either side of type hint colon
