### PR TITLE
Disabling a few things in the PHP CS Fixer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor
+.php_cs.cache

--- a/.php_cs
+++ b/.php_cs
@@ -103,7 +103,6 @@ return PhpCsFixer\Config::create()
         'phpdoc_add_missing_param_annotation' => true,
         'phpdoc_order' => true,
         'phpdoc_scalar' => true,
-        'phpdoc_separation' => true,
         'phpdoc_single_line_var_spacing' => true,
         'single_trait_insert_per_statement' => true,
         'ordered_class_elements' => [
@@ -112,9 +111,6 @@ return PhpCsFixer\Config::create()
                 'constant',
                 'property',
                 'construct',
-                'public',
-                'protected',
-                'private',
             ],
             'sortAlgorithm' => 'none',
         ],


### PR DESCRIPTION
Removing some rules from the base PHP CS Fixer that IMO are a bit annoying. Sometimes you may want to group your methods in a different way the public, protected and then private.

Also, `phpdoc_separation` seems to just add noise with no value, unless there's a good reasons I suggest we remove it as well.

In projects that don't have this rule, just going and saving a file change the whole file, and make code reviews hard.