### PR TITLE
Update definition filename in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,11 +8,11 @@
 #### Inspections (fixer does not run, only highlights violations)
 1. Set the correct php cs fixer binary in:
     - Language & Frameworks -> PHP -> Quality tools
-2. Place the KDG custom .php_cs configuration file in your home directory
+2. Place the KDG custom .php-cs-fixer.php configuration file in your home directory
 3. Within phpstorm, go to:
     - Settings -> Editor -> Inspections -> PHP -> Quality tools
     - Make sure PHP CS Fixer validation is checked
-    - In the right hand pane, after selecting this option, click the browse (`...`) button and select the .php_cs file previously saved in your home directory
+    - In the right hand pane, after selecting this option, click the browse (`...`) button and select the .php-cs-fixer.php file previously saved in your home directory
     - Ensure PHP Code Sniffer validation is also set to this Coding Standard in its right pane
     - Click Apply and OK
 #### File Watcher (fixer runs on save action)
@@ -24,13 +24,13 @@ Name: PHP Style fixer
 File type: PHP
 Scope: Current File
 Path: /{your-global-composer-directory}/vendor/friendsofphp/php-cs-fixer/php-cs-fixer
-Arguments: fix $FileDir$/$FileName$ --verbose --config={path-to-your-root-php-cs-dir}/php-cs/.php_cs
+Arguments: fix $FileDir$/$FileName$ --verbose --config={path-to-your-root-php-cs-dir}/php-cs/.php-cs-fixer.php
 ```
 ## VS Code
 1. Install [PHP CS Fixer](https://marketplace.visualstudio.com/items?itemName=fterrag.vscode-php-cs-fixer) extension
 2. Configure Extension, in `Settings as JSON`
     ```
-    "vscode-php-cs-fixer.config": "/{path_to_repository}/.php_cs",
+    "vscode-php-cs-fixer.config": "/{path_to_repository}/.php-cs-fixer.php",
     "vscode-php-cs-fixer.toolPath": "/{path_to_repository}/vendor/bin/php-cs-fixer",
     "[php]": {
         "editor.defaultFormatter": "fterrag.vscode-php-cs-fixer"
@@ -41,7 +41,7 @@ Arguments: fix $FileDir$/$FileName$ --verbose --config={path-to-your-root-php-cs
 2. Under Preferences -> Package Settings -> PHP CS Fixer -> Settings - User, configure the extension using the following JSON
     ```
     {
-        "config": "/path/to/kirschbaum-development/php-cs/.php_cs",
+        "config": "/path/to/kirschbaum-development/php-cs/.php-cs-fixer.php",
         "on_save": true,
     }
     ```


### PR DESCRIPTION
The `.php_cs` file was renamed to `.php-cs-fixer.php` in a previous update.  This change reflects that update in the docs.